### PR TITLE
Remove set_creator method because of duplicate

### DIFF
--- a/lib/chainer/function.rb
+++ b/lib/chainer/function.rb
@@ -31,7 +31,7 @@ module Chainer
       if Chainer.configuration.enable_backprop
         @rank = inputs.map(&:rank).max || 0
 
-        ret.each { |y| y.set_creator(self) }
+        ret.each { |y| y.creator = self }
 
         @inputs = inputs.map(&:node)
         @outputs = ret.map { |y| WeakRef.new(y.node) }

--- a/lib/chainer/variable.rb
+++ b/lib/chainer/variable.rb
@@ -71,10 +71,6 @@ module Chainer
       @node.grad = nil
     end
 
-    def set_creator(gen_func)
-      @node.set_creator(gen_func)
-    end
-
     def backward(retain_grad: false)
       return if self.creator.nil?
 

--- a/lib/chainer/variable_node.rb
+++ b/lib/chainer/variable_node.rb
@@ -41,10 +41,6 @@ module Chainer
       end
     end
 
-    def set_creator(creator)
-      self.creator = creator
-    end
-
     def unchain
       @creator = nil
     end


### PR DESCRIPTION
Methods `set_creator` and `creator=` are same mean.
We should choose Rubyish one.