### PR TITLE
Add require 'time' to use Time.parse

### DIFF
--- a/lib/chainer/training/extensions/progress_bar.rb
+++ b/lib/chainer/training/extensions/progress_bar.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'time'
 
 module Chainer
   module Training


### PR DESCRIPTION
`require 'time'` is needed to avoid a following error:

```
        6: from examples/mnist/mnist.rb:82:in `<main>'
        5: from /home/sonots/src/github.com/red-data-tools/red-chainer/lib/chainer/training/trainer.rb:116:in `run'
        4: from /home/sonots/src/github.com/red-data-tools/red-chainer/lib/chainer/reporter.rb:60:in `scope'
        3: from /home/sonots/src/github.com/red-data-tools/red-chainer/lib/chainer/training/trainer.rb:118:in `block in run'
        2: from /home/sonots/src/github.com/red-data-tools/red-chainer/lib/chainer/training/trainer.rb:118:in `each'
        1: from /home/sonots/src/github.com/red-data-tools/red-chainer/lib/chainer/training/trainer.rb:119:in `block (2 levels) in run'
/home/sonots/src/github.com/red-data-tools/red-chainer/lib/chainer/training/extensions/progress_bar.rb:73:in `call': undefined method `parse' for Time:Class (NoMethodError)
```