### PR TITLE
Improvement of the mnist calculation processing being degraded in Ruby 2.5.

### DIFF
--- a/lib/chainer/datasets/mnist.rb
+++ b/lib/chainer/datasets/mnist.rb
@@ -41,7 +41,9 @@ module Chainer
         train_table = ::Datasets::MNIST.new(type: type).to_table
 
         xm = Chainer::Device.default.xm
-        { x: xm::UInt8[*train_table[:pixels]], y: xm::UInt8[*train_table[:label]] }
+        Proc.new { # Use Proc.new & call to avoid speed reduction in Ruby 2.5 or lower. It is unnecessary in Ruby 2.6 because it does not occur.
+          { x: xm::UInt8[*train_table[:pixels]], y: xm::UInt8[*train_table[:label]] }
+        }.call
       end
     end
   end


### PR DESCRIPTION
This problem now occurs in #64.
However, it does not occur in Ruby 2.6.0.
It seems like a problem with Ruby 2.5, but because of its significant performance impact I have created this pull request.
Since it is possible that it may occur in other than the mnist data set, it may be better to recommend red-chainer 2.6.0 or later.

## Ruby 2.5.3 red-chainer-0.3.2.gem (no problem)
<pre>
$ ruby  -r numo/linalg/use/openblas /home/naitoh/.rvm/gems/ruby-2.5.3/gems/red-chainer-0.3.2/examples/mnist/mnist.rb  --epoch 1
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.192171    0.127181              0.942166       0.956                     26.9086    
</pre>
## Ruby 2.6.0 red-chainer-0.3.2.gem (no problem)
<pre>
$ ruby  -r numo/linalg/use/openblas /home/naitoh/.rvm/gems/ruby-2.6.0/gems/red-chainer-0.3.2/examples/mnist/mnist.rb  --epoch 1
epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.192101    0.104019              0.940867       0.9688                    26.7307  
</pre>

## Ruby 2.5.3 red-chainer master (4d3b05edcecf3241bb95dbe34f1879dcaccd0157) (too slow)
<pre>
$ ruby  -r numo/linalg/use/openblas /home/naitoh/.rvm/gems/ruby-2.5.3/gems/red-chainer-0.3.3/examples/mnist/mnist.rb  --epoch 1
GPU: -1
# unit: 1000
# Minibatch-size: 100
# epoch: 1

epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.189171    0.0858522             0.941933       0.9738                    47.6165       
</pre>
## Ruby 2.6.0 red-chainer master (4d3b05edcecf3241bb95dbe34f1879dcaccd0157) (no problem)
<pre>
$ ruby  -r numo/linalg/use/openblas /home/naitoh/.rvm/gems/ruby-2.6.0/gems/red-chainer-0.3.3/examples/mnist/mnist.rb  --epoch 1
GPU: -1
# unit: 1000
# Minibatch-size: 100
# epoch: 1

epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.190919    0.0971196             0.942066       0.9701                    27.1845  
</pre>

## Ruby 2.5.3 Proc.new & call added (this pull request)
<pre>
$ ruby  -r numo/linalg/use/openblas /home/naitoh/.rvm/gems/ruby-2.5.3/gems/red-chainer-0.3.4/examples/mnist/mnist.rb  --epoch 1
GPU: -1
# unit: 1000
# Minibatch-size: 100
# epoch: 1

epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.191402    0.0972073             0.942134       0.9689                    27.794
</pre>
## Ruby 2.6.0 Proc.new & call added (this pull request)
<pre>
$ ruby  -r numo/linalg/use/openblas /home/naitoh/.rvm/gems/ruby-2.6.0/gems/red-chainer-0.3.4/examples/mnist/mnist.rb  --epoch 1
GPU: -1
# unit: 1000
# Minibatch-size: 100
# epoch: 1

epoch       main/loss   validation/main/loss  main/accuracy  validation/main/accuracy  elapsed_time
1           0.192142    0.104178              0.941734       0.9682                    27.4271       
</pre>

## Environment

* CentOS Linux release 7.3.1611 (Core) x86_64
* ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
* ruby 2.6.0p0 (2018-12-25 revision 66547) [x86_64-linux]
* numo-linalg (0.1.3) master (d727b353b9190d16b4642c4fabe001dcb42bc682 (same 7111b6c4897bbb22f3011b5b608c20875a70ba4f))
* numo-narray (0.9.1.3) master (795a5f80ed65ea1f8c116f809a490f63dda42300)
