### PR TITLE
CI Build Error fixed and Ruby 2.6.0 added.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
-before_install: gem install bundler -v 1.15.1
+before_install: gem install bundler
 script: ruby test/run_test.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ rvm:
   - 2.3.6
   - 2.4.3
   - 2.5.0
+  - 2.6.0
 before_install: gem install bundler
 script: ruby test/run_test.rb

--- a/red-chainer.gemspec
+++ b/red-chainer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "numo-narray", ">= 0.9.1.1"
   spec.add_runtime_dependency "red-datasets", ">= 0.0.6"
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit", ">= 3.2.9"
 end


### PR DESCRIPTION
In Travis CI, a build error has occurred due to a bundler version (default 2.0.1) problem.

Although bundler 1.15.1 is installed, this is an error because it is never used. (As 2.0.1 is used, it will be inconsistent with "bundler", "~> 1.15".)
Therefore, I deleted bundler version specification.

```
$ ruby --version
ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-linux]
$ rvm --version
rvm 1.29.3 (latest) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]
$ bundle --version
Bundler version 2.0.1
$ gem --version
2.6.14
before_install
0.47s$ gem install bundler -v 1.15.1
Fetching: bundler-1.15.1.gem (100%)
Successfully installed bundler-1.15.1
1 gem installed
8.61s$ bundle install --jobs=3 --retry=3
Fetching gem metadata from https://rubygems.org/.............
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 1.15)
  Current Bundler version:
    bundler (2.0.1)
This Gemfile requires a different version of Bundler.
```

In addition, I added a build of Ruby 2.6.