### PR TITLE
Fix require "chainer"

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "red-chainer"
+require "chainer"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.


### PR DESCRIPTION
I've fixed the following error when using `bin/console`.
```
$ bin/console

Traceback (most recent call last):
	1: from bin/console:4:in `<main>'
bin/console:4:in `require': cannot load such file -- red-chainer (LoadError)
```