### PR TITLE
YARD and MathJax document (like rubydoc.info).

### DIFF
--- a/templates/default/layout/html/layout.erb
+++ b/templates/default/layout/html/layout.erb
@@ -13,7 +13,7 @@
       });
     </script>
     <script type="text/javascript"
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <meta http-equiv="X-UA-Compatible" CONTENT="IE=EmulateIE7" />
     <!-- Additional settings for MathJax are over here. -->

--- a/templates/default/layout/html/layout.erb
+++ b/templates/default/layout/html/layout.erb
@@ -13,7 +13,7 @@
       });
     </script>
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <meta http-equiv="X-UA-Compatible" CONTENT="IE=EmulateIE7" />
     <!-- Additional settings for MathJax are over here. -->

--- a/templates/default/onefile/html/layout.erb
+++ b/templates/default/onefile/html/layout.erb
@@ -16,7 +16,7 @@
       });
     </script>
     <script type="text/javascript"
-      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <meta http-equiv="X-UA-Compatible" CONTENT="IE=EmulateIE7" />
     <!-- Additional settings for MathJax are over here. -->

--- a/templates/default/onefile/html/layout.erb
+++ b/templates/default/onefile/html/layout.erb
@@ -16,7 +16,7 @@
       });
     </script>
     <script type="text/javascript"
-      src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
+      src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML">
     </script>
     <meta http-equiv="X-UA-Compatible" CONTENT="IE=EmulateIE7" />
     <!-- Additional settings for MathJax are over here. -->


### PR DESCRIPTION
YARD and MathJax were supported by #75, but rubydoc.info doesn't seem to display mathjax correctly.
(See. https://www.rubydoc.info/gems/red-chainer/0.4.1/Chainer/Functions/Activation/Relu)

The following was created as a sample to display correctly.

https://naitoh.github.io/red-chainer/red-chainer/
https://naitoh.github.io/red-chainer/red-chainer/Chainer/Functions/Activation/Relu.html

The above contains everything under the doc / directory generated by the yard doc command.
(It was necessary to modify http to https, so layout.rb fixed in this PR.)

I would like to host this at the URL below, what do you think?

https://red-data-tools.github.io/red-chainer/red-chainer/
